### PR TITLE
Fix typo in agendamentos list template

### DIFF
--- a/agendamentos/templates/agendamentos/listar.html
+++ b/agendamentos/templates/agendamentos/listar.html
@@ -14,8 +14,8 @@
 <div class="header-agendamento">
     <h2>📅 Agendamentos</h2>
     <a href="{% url 'criar_agendamento' %}" class="botao-novo">+ Novo Agendamento</a>
-    <a href="{% url 'estatisticas_diarias' %}" class="botao-novo">Grafico lavagens Diarias</a>
-    <a href="{% url 'estatisticas_mensais' %}" class="botao-novo">Grafico lavagens Mensais</a>
+    <a href="{% url 'estatisticas_diarias' %}" class="botao-novo">Gráfico Lavagens Diárias</a>
+    <a href="{% url 'estatisticas_mensais' %}" class="botao-novo">Gráfico Lavagens Mensais</a>
 </div>
 
 


### PR DESCRIPTION
## Summary
- fix accentuation in statistical chart links in list page

## Testing
- `pytest -q`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68407ef134fc83219887315e5d059f52